### PR TITLE
feat: update spmv-hypersparse to support wse-3

### DIFF
--- a/benchmarks/spmv-hypersparse/commands_wse3.sh
+++ b/benchmarks/spmv-hypersparse/commands_wse3.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+# WSE-3 support contributed by Integrated Reasoning, Inc.
+# https://www.integrated-reasoning.com
+# david@integrated-reasoning.com
 
 set -e
 
-cslc ./src/layout.csl --arch wse2 --fabric-dims=11,6 --fabric-offsets=4,1 \
+cslc ./src/layout.csl --arch wse3 --fabric-dims=11,6 --fabric-offsets=4,1 \
 --params=ncols:16,nrows:16,pcols:4,prows:4,max_local_nnz:8 \
 --params=max_local_nnz_cols:4,max_local_nnz_rows:4,local_vec_sz:1 \
 --params=local_out_vec_sz:1,y_pad_start_row_idx:4 -o=out \

--- a/benchmarks/spmv-hypersparse/src/hypersparse_spmv/pe.csl
+++ b/benchmarks/spmv-hypersparse/src/hypersparse_spmv/pe.csl
@@ -17,7 +17,7 @@
 param f_callback : fn ()void;
 
 param input_queues:[4]u16;
-param output_queues:[2]u16;
+param output_queues:[4]u16;
 
 // explicit DSR allocation
 param dest_dsr_ids:[6]u16;
@@ -176,7 +176,7 @@ var tsc_reduce_end_buffer = @zeros([timestamp.tsc_size_words]u16);
 // var TSC_VALUE_TO_WAIT_UNTIL = [3]u16 { 0x9c40, 0x0, 0x0 };        // 40K cycles
 var TSC_VALUE_TO_WAIT_UNTIL = [3]u16 { 0x3e8, 0x0, 0x0 };         // 1K cycles
 
-// WARNING: reserve input/output queue 0 for memcpy module
+// WARNING: input/output queues must avoid reserved queues.
 // uthreads for fabric data movement
 const RX_NORTH_Q: u16 = input_queues[0];
 const RX_SOUTH_Q: u16 = input_queues[1];
@@ -184,8 +184,8 @@ const TX_NORTH_Q: u16 = output_queues[0];
 const TX_SOUTH_Q: u16 = output_queues[1];
 // reduction trains, corresponding rx and tx are not active simultaneously
 // NOTE: the two phases are exclusive, so uthreads can actually be reused from north-south
-const TX_WEST_Q: u16 = output_queues[0];
-const TX_EAST_Q: u16 = output_queues[1];
+const TX_WEST_Q: u16 = output_queues[2];
+const TX_EAST_Q: u16 = output_queues[3];
 const RX_WEST_Q: u16 = input_queues[2];
 const RX_EAST_Q: u16 = input_queues[3];
 
@@ -292,49 +292,41 @@ const rx_south_dsd = @get_dsd(fabin_dsd, .{
 });
 const tx_north_dsd = @get_dsd(fabout_dsd, .{
     .extent = local_vec_sz,                 // fp32 => 1 per wavelet
-    .fabric_color = north_train,
     .output_queue = @get_output_queue(TX_NORTH_Q),
 });
 const tx_south_dsd = @get_dsd(fabout_dsd, .{
     .extent = local_vec_sz,
-    .fabric_color = south_train,
     .output_queue = @get_output_queue(TX_SOUTH_Q),
 });
 const tx_north_ctrl_adv_dsd = @get_dsd(fabout_dsd, .{
     .extent = 2,    // two switch wavelets
     .control = true,
-    .fabric_color = north_train,
     .output_queue = @get_output_queue(TX_NORTH_Q),
 });
 const tx_south_ctrl_adv_dsd = @get_dsd(fabout_dsd, .{
     .extent = 2,    // two switch wavelets
     .control = true,
-    .fabric_color = south_train,
     .output_queue = @get_output_queue(TX_SOUTH_Q),
 });
 const tx_north_ctrl_rst_dsd = @get_dsd(fabout_dsd, .{
     .extent = 1,    // two switch wavelets
     .control = true,
-    .fabric_color = north_train,
     .output_queue = @get_output_queue(TX_NORTH_Q),
 });
 const tx_south_ctrl_rst_dsd = @get_dsd(fabout_dsd, .{
     .extent = 1,    // two switch wavelets
     .control = true,
-    .fabric_color = south_train,
     .output_queue = @get_output_queue(TX_SOUTH_Q),
 });
 
 // 2. reduce phase: west and east trains for partial output vectors (sparse: vals + rows)
 const tx_west_dsd = @get_dsd(fabout_dsd, .{
     .extent = 1,
-    .fabric_color = tx_west_train,
     .output_queue = @get_output_queue(TX_WEST_Q),
 });
 
 const tx_east_dsd = @get_dsd(fabout_dsd, .{
     .extent = 1,
-    .fabric_color = tx_east_train,
     .output_queue = @get_output_queue(TX_EAST_Q),
 });
 
@@ -1888,14 +1880,23 @@ comptime {
 // the compiler no longer can generate the instruction to set up the
 // config register of input queue.
 comptime {
-    // color south_train maps to RX_NORTH_Q: u16 = 4;
-    // color north_train maps to RX_SOUTH_Q: u16 = 1;
-    // color rx_east_train maps to RX_WEST_Q: u16 = 6;
-    // color rx_west_train maps to RX_EAST_Q: u16 = 7;
+    // color south_train maps to RX_NORTH_Q: u16 = 2;
+    // color north_train maps to RX_SOUTH_Q: u16 = 3;
+    // color rx_east_train maps to RX_WEST_Q: u16 = 4;
+    // color rx_west_train maps to RX_EAST_Q: u16 = 5;
     @initialize_queue(@get_input_queue(RX_NORTH_Q), .{.color = south_train});
     @initialize_queue(@get_input_queue(RX_SOUTH_Q), .{.color = north_train});
     @initialize_queue(@get_input_queue(RX_WEST_Q), .{.color = rx_east_train});
     @initialize_queue(@get_input_queue(RX_EAST_Q), .{.color = rx_west_train});
+}
+
+comptime {
+    if (@is_arch("wse3")) {
+        @initialize_queue(@get_output_queue(TX_NORTH_Q), .{.color = north_train});
+        @initialize_queue(@get_output_queue(TX_SOUTH_Q), .{.color = south_train});
+        @initialize_queue(@get_output_queue(TX_WEST_Q), .{.color = tx_west_train});
+        @initialize_queue(@get_output_queue(TX_EAST_Q), .{.color = tx_east_train});
+    }
 }
 
 comptime {

--- a/benchmarks/spmv-hypersparse/src/kernel.csl
+++ b/benchmarks/spmv-hypersparse/src/kernel.csl
@@ -17,8 +17,6 @@ param memcpyParams;
 
 param spmvParams;
 
-param reduceParams;
-
 // parameters
 param nrows: u32;   // total number of matrix rows
 param ncols: u32;   // total number of matrix cols (= nrows)
@@ -51,14 +49,11 @@ var local_nnz_rows = @zeros([1]u16);    // actual local number of nnz rows
 // final reduced local output vector (dense)
 var y_local_buf = @zeros([local_out_vec_sz]f32);
 
-// temporary buffer for allreduce
-var dot = @zeros([1]f32);
-
 const timestamp = @import_module("<time>");
 
 const sys_mod = @import_module( "<memcpy/memcpy>", memcpyParams);
 
-// input_queues cannot overlap with output_queues
+// input_queues/output_queues must avoid memcpy-reserved queues.
 const spmv_mod = @import_module( "hypersparse_spmv/pe.csl", .{
      .spmv_params = spmvParams,
      .f_callback = sys_mod.unblock_cmd_stream,
@@ -82,33 +77,22 @@ const spmv_mod = @import_module( "hypersparse_spmv/pe.csl", .{
      .local_nnz_cols = &local_nnz_cols,
      .local_nnz_rows = &local_nnz_rows,
 
-     .input_queues=[4]u16{4, 1, 6, 7},
-     .output_queues=[2]u16{2,3},
+     .input_queues=[4]u16{2, 3, 4, 5},
+     .output_queues=[4]u16{4, 5, 2, 3},
      .dest_dsr_ids = [6]u16{1, 4, 5, 6, 2, 3},
      .src1_dsr_ids = [6]u16{4, 1, 6, 7, 2, 3},
-     });
-
-// allreduce uses input queue/output queue 5
-// dest_dsr and src0_dsr must be a valid pair, for example (7,1) is invalid
-const reduce_mod = @import_module( "allreduce2R1E/pe.csl", .{
-     .reduce_params = reduceParams,
-     .f_callback = sys_mod.unblock_cmd_stream,
-     .MAX_ZDIM = 1,
-     .queues = [1]u16{5},
-     .dest_dsr_ids = [1]u16{7},
-     .src0_dsr_ids = [1]u16{7},
-     .src1_dsr_ids = [1]u16{5}
      });
 
 // tsc library
 var tsc_start_buffer = @zeros([timestamp.tsc_size_words]u16);
 var tsc_end_buffer = @zeros([timestamp.tsc_size_words]u16);
+var tsc_wait_until = [timestamp.tsc_size_words]u16{ 0x3e8, 0x0, 0x0 };
 
 // time_buf_u16[0:5] = {tsc_start_buffer, tsc_end_buffer}
 var time_buf_u16 = @zeros([timestamp.tsc_size_words*2]u16);
 var ptr_time_buf_u16: [*]u16 = &time_buf_u16;
 
-// reference clock inside allreduce module
+// reference clock for host timing alignment
 var time_ref_u16 = @zeros([timestamp.tsc_size_words]u16);
 var ptr_time_ref_u16: [*]u16 = &time_ref_u16;
 
@@ -171,15 +155,41 @@ fn f_memcpy_timestamps() void {
     sys_mod.unblock_cmd_stream();
 }
 
-fn f_sync( n: i16 ) void {
-   reduce_mod.allreduce(n, &dot);
+fn is_less_than(aval: *[timestamp.tsc_size_words]u16, bval: *[timestamp.tsc_size_words]u16) bool {
+    if ((aval.*)[2] < (bval.*)[2]) {
+        return true;
+    } else if ((aval.*)[2] == (bval.*)[2]) {
+        if ((aval.*)[1] < (bval.*)[1]) {
+            return true;
+        } else if ((aval.*)[1] == (bval.*)[1]) {
+            if ((aval.*)[0] < (bval.*)[0]) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+fn f_sync(n: i16) void {
+    if (n == -1) {
+        time_ref_u16[0] = time_ref_u16[0];
+    }
+    var curr = @zeros([timestamp.tsc_size_words]u16);
+    while (true) {
+        timestamp.get_timestamp(&curr);
+        if (!is_less_than(&curr, &tsc_wait_until)) {
+            break;
+        }
+    }
+    time_ref_u16[0] = curr[0];
+    time_ref_u16[1] = curr[1];
+    time_ref_u16[2] = curr[2];
+
+    sys_mod.unblock_cmd_stream();
 }
 
 fn f_reference_timestamps() void {
-
-    time_ref_u16[0] = reduce_mod.tscRefBuffer[0];
-    time_ref_u16[1] = reduce_mod.tscRefBuffer[1];
-    time_ref_u16[2] = reduce_mod.tscRefBuffer[2];
+    timestamp.get_timestamp(&time_ref_u16);
 
     // the user must unblock cmd color for every PE
     sys_mod.unblock_cmd_stream();

--- a/benchmarks/spmv-hypersparse/src/layout.csl
+++ b/benchmarks/spmv-hypersparse/src/layout.csl
@@ -21,9 +21,9 @@
 //   4  c3             14  tx_south         24   compute_local        34 reserved (memcpy)
 //   5  c4             15  rx_north         25   curr_rx_north_done   35 reserved (memcpy)
 //   6  c5             16  rx_south         26   curr_rx_south_done   36 reserved (memcpy)
-//   7  allreduce_c0   17  rx_east          27   reserved (memcpy)    37 reserved (memcpy)
-//   8  allreduce_c1   18  rx_west          28   reserved (memcpy)
-//   9  allreduce_EN1  19  tx_west          29   reserved (memcpy)
+//   7                 17  rx_east          27   reserved (memcpy)    37 reserved (memcpy)
+//   8                 18  rx_west          28   reserved (memcpy)
+//   9                 19  tx_west          29   reserved (memcpy)
 
 // routable colors for spmv
 param c0 = @get_color(1);
@@ -32,12 +32,6 @@ param c2 = @get_color(3);
 param c3 = @get_color(4);
 param c4 = @get_color(5);
 param c5 = @get_color(6);
-
-// routable colors for allreduce
-param allreduce_c0 = @get_color(7);
-param allreduce_c1 = @get_color(8);
-// entrypoint for allreduce
-param allreduce_EN1: local_task_id = @get_local_task_id(9);
 
 // entrypoints for spmv
 param EN1: local_task_id = @get_local_task_id(10);
@@ -82,14 +76,6 @@ const spmv = @import_module( "hypersparse_spmv/layout.csl", .{
     .width = pcols,
     .height = prows
     });
-
-const reduce = @import_module( "allreduce2R1E/layout.csl", .{
-    .colors = [2]color{allreduce_c0, allreduce_c1},
-    .entrypoints = [1]local_task_id{allreduce_EN1},
-    .width = pcols,
-    .height = prows
-    });
-
 const memcpy = @import_module( "<memcpy/get_params>", .{
     .width = pcols,
     .height = prows,
@@ -115,11 +101,9 @@ layout {
 
             const memcpyParams = memcpy.get_params(pcol_id);
             const spmvParams = spmv.get_params(pcol_id, prow_id);
-            const reduceParams = reduce.get_params(pcol_id, prow_id);
             var params = .{
                 .memcpyParams = memcpyParams,
                 .spmvParams = spmvParams,
-                .reduceParams = reduceParams,
                 .nrows = nrows,
                 .ncols = ncols,
                 .local_vec_sz = local_vec_sz,


### PR DESCRIPTION
## Summary

Port benchmarks/spmv-hypersparse to WSE-3.

## Details

  - Remapped SpMV input queues from `{4, 1, 6, 7}` to `{2, 3, 4, 5}` to avoid `queue 1`, which WSE-3 `memcpy` uses.
  - Expanded SpMV output queues from 2 to 4 so north/south/west/east TX paths use distinct output queues.
  - Added WSE-3 output queue initialization with the appropriate fabric colors.
  - Removed `allreduce2R1E` from the layout/kernel path, freeing `queue 5` for SpMV.
  - Replaced `allreduce`-based sync with local timestamp-based sync.
  - Removed deprecated `.fabric_color` fields from fabout DSDs; WSE-3 colors now come from queue initialization.
  - Replaced `commands_wse2.sh` with  `commands_wse3.sh` which uses `--arch wse3`.

## Testing

Via simulation on SDK version 2.10.0.

<details>
<summary>
Original WSE-2 spmv-hypersparse host logs:
</summary>

```bash
david in 🌐 nixos-0 in sdk-examples/benchmarks/spmv-hypersparse on  master [$+] via 🐍 v3.13.8 via ❄️  impure (nix-shell-env) on ☁️  (us-west-2) ζ ➜ ./commands_wse2.sh
[INFO] === Beginning compilation ===
[INFO] Compilation successful
[INFO] === Calling SDK python ===
cslc = cslc
width_west_buf = 0
width_east_buf = 0
channels = 1
width = 4, height = 4
infile_mtx = ./data/rmat4.4x4.lb.mtx
Load matrix A, 16-by-16 with 108 nonzeros
prepare the structure for spmv kernel: 0.012461423873901367s
Generating reference y = A*x ...
Total memory use per PE = 200 bytes = 0.1953125 KB
fabric_width = 11, fabric_height = 6
core_fabric_offset_x = 4, core_fabric_offset_y = 1
store ELFs and log files in the folder  out
[csl_compile_core] use pre-compile ELFs
Compilation done in 8.106231689453125e-06s
*** Load done in 3.8623809814453125e-05s
step 1: enable tsc counter to sample the clock
step 2: copy the structure of A and vector x to the device
step 3: sync all PEs to sample the reference clock
step 4: tic() records time_start
step 5: spmv
step 5: toc() records time_end
step 6: prepare (time_start, time_end)
step 7: fetch the timing time_buf_u16[6] = (time_start, time_end), type = u16
step 8: fetch the output vector y of type f32
step 9: prepare reference clock
step 10: D2H reference clock
*** Run done in 4.725285530090332s
cycles_send = 6308 cycles
time_send = 7.421176470588235 us
bandwidth = 118.57958148383005 MB/S
Comparing result with reference...
reference[16]:
[7.4496174 4.7344646 2.8157272 0.9724683 6.1381197 3.54332   3.2193651
 2.5113463 5.151715  4.040394  3.164474  2.6652527 6.0831847 6.714239
 3.694953  1.3090382]
result   [16]:
[7.4496174 4.7344646 2.8157275 0.9724683 6.1381197 3.5433197 3.219365
 2.5113463 5.151715  4.040394  3.164474  2.6652527 6.0831842 6.714239
 3.694953  1.3090382]
[[ Absolute diff: 1.1920928955078125e-06 ]]
[[ Average diff : 7.450580596923828e-08 ]]
[[ Result within tolerance 1e-08: PASS ]]
[[ Result within tolerance 1e-08: PASS ]]
```
</details>

<details>
<summary>
Original WSE-2 spmv-hypersparse simulator logs:
</summary>

```bash
david in 🌐 nixos-0 in sdk-examples/benchmarks/spmv-hypersparse on  master [$+?] via 🐍 v3.13.8 via ❄️  impure (nix-shell-env) on ☁️  (us-west-2) took 10s ζ ➜ cat sim.log
@0 GITREV=4586d3f0d8b1e12bc435ce5c7e6436ee6ae2b9b8, GITCLEAN=1
@0 Create from elfs
@0 sizeof(struct hwtile):     209888 bytes
@0 sizeof(      instr_t):       1584 bytes
@0 sizeof(     decode_t):        148 bytes
@0 sizeof(     memreq_t):         24 bytes
@0 sizeof(        dsr_t):        304 bytes
@0 sizeof(      exops_t):       6584 bytes
@0 sizeof(hwtile_follow):     207840 bytes
@0 sizeof(struct hwtile):     209888 bytes
@0 sizeof(      instr_t):       1584 bytes
@0 sizeof(     decode_t):        148 bytes
@0 sizeof(     memreq_t):         24 bytes
@0 sizeof(        dsr_t):        304 bytes
@0 sizeof(      exops_t):       6584 bytes
@0 sizeof(hwtile_follow):     207840 bytes
@0 dimX=11, dimY=6
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/default.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/coord.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_7_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_15_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_6_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_14_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_8_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_9_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_13_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_12_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_11_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_10_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_6_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_7_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/MEMCPY_XY_ROUTES.elf
@0 Invocation key is: sim404D33EEF8A621135E308BD153B4D518
@0 Plan key is: plan34A3D4139F5F8BE0CD504134808A3823
@0 SimTraceCtf, flags:  wavelets=0 landing=1 inst=1 switch_positions=0 stalls=1
@0 P0.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P2.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P3.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P4.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P5.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P6.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P7.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P8.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P9.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P10.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P1.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.1 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.2 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.2 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.3 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P0.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P1.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P0.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P2.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P3.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P4.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P5.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P6.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P7.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P8.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P9.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P10.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW1 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LW2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW4 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LW5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE3 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LE4 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LE5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN4 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN6 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN7 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN8 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN9 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN10 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS4 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS6 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS7 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS8 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS9 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS10 (nul) tile trace flag: inst_trace,landing,stalls
@0 Architecture is: FYN
@0 Simtile is: hwtile
@0 Sim stats: config-time=0.04, nodes=1, threads=5
@0 Sim stats: tiles=100, simulated_tiles=44, hwtile=40, iotile=4, nultile=56
@24661 50 cycles since an instruction was executed, 81 cycles since a wavelet landed
@24661 No data movement in the last 50 cycles; stopping.
@24661 Simulation used 4.68 seconds, init-time=0.05, total-time=4.72, cycles=24661, cyc/sec=5274.36, tile-cyc/sec=232071.86, tile-cyc/sec-thread=46414.37
@24661 CTF Stats: num_stalls_       =      2332354
@24661 CTF Stats: num_wavelets      =        19682
@24661 CTF Stats: num_inst_dispatch =       297197
@24661 CTF Stats: num_inst_pipe     =       598005
@24661 CTF Stats: num_switch_pos    =            0
```
</details>

<details>
<summary>
Patched WSE-3 spmv-hypersparse host logs:
</summary>

```bash
david in 🌐 nixos-0 in sdk-examples/benchmarks/spmv-hypersparse on  master [$✘!+?] via 🐍 v3.13.8 via ❄️  impure (nix-shell-env) on ☁️  (us-west-2) ζ ➜ ./commands_wse3.sh
[INFO] === Beginning compilation ===
[INFO] Compilation successful
[INFO] === Calling SDK python ===
cslc = cslc
width_west_buf = 0
width_east_buf = 0
channels = 1
width = 4, height = 4
infile_mtx = ./data/rmat4.4x4.lb.mtx
Load matrix A, 16-by-16 with 108 nonzeros
prepare the structure for spmv kernel: 0.011369705200195312s
Generating reference y = A*x ...
Total memory use per PE = 200 bytes = 0.1953125 KB
fabric_width = 11, fabric_height = 6
core_fabric_offset_x = 4, core_fabric_offset_y = 1
store ELFs and log files in the folder  out
[csl_compile_core] use pre-compile ELFs
Compilation done in 5.9604644775390625e-06s
*** Load done in 3.814697265625e-05s
step 1: enable tsc counter to sample the clock
step 2: copy the structure of A and vector x to the device
step 3: sync all PEs to sample the reference clock
step 4: tic() records time_start
step 5: spmv
step 5: toc() records time_end
step 6: prepare (time_start, time_end)
step 7: fetch the timing time_buf_u16[6] = (time_start, time_end), type = u16
step 8: fetch the output vector y of type f32
step 9: prepare reference clock
step 10: D2H reference clock
*** Run done in 4.242101430892944s
cycles_send = 5275 cycles
time_send = 6.205882352941177 us
bandwidth = 141.80094786729856 MB/S
Comparing result with reference...
reference[16]:
[7.4496174 4.7344646 2.8157272 0.9724683 6.1381197 3.54332   3.2193651
 2.5113463 5.151715  4.040394  3.164474  2.6652527 6.0831847 6.714239
 3.694953  1.3090382]
result   [16]:
[7.4496174 4.7344646 2.8157275 0.9724683 6.1381197 3.5433197 3.219365
 2.5113463 5.151715  4.040394  3.164474  2.6652527 6.0831842 6.714239
 3.694953  1.3090382]
[[ Absolute diff: 1.1920928955078125e-06 ]]
[[ Average diff : 7.450580596923828e-08 ]]
[[ Result within tolerance 1e-08: PASS ]]
[[ Result within tolerance 1e-08: PASS ]]
```
</details>

<details>
<summary>
Patched WSE-3 spmv-hypersparse simulator logs:
</summary>

```bash
david in 🌐 nixos-0 in sdk-examples/benchmarks/spmv-hypersparse on  master [$✘!+?] via 🐍 v3.13.8 via ❄️  impure (nix-shell-env) on ☁️  (us-west-2) took 9s ζ ➜ cat sim.log
@0 GITREV=4586d3f0d8b1e12bc435ce5c7e6436ee6ae2b9b8, GITCLEAN=1
@0 Create from elfs
@0 sizeof(struct hwtile):     209888 bytes
@0 sizeof(      instr_t):       1584 bytes
@0 sizeof(     decode_t):        148 bytes
@0 sizeof(     memreq_t):         24 bytes
@0 sizeof(        dsr_t):        304 bytes
@0 sizeof(      exops_t):       6584 bytes
@0 sizeof(hwtile_follow):     207840 bytes
@0 sizeof(struct hwtile):     209888 bytes
@0 sizeof(      instr_t):       1584 bytes
@0 sizeof(     decode_t):        148 bytes
@0 sizeof(     memreq_t):         24 bytes
@0 sizeof(        dsr_t):        304 bytes
@0 sizeof(      exops_t):       6584 bytes
@0 sizeof(hwtile_follow):     207840 bytes
@0 dimX=11, dimY=6
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/default.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/coord.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_7_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_13_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_6_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_15_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_8_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_9_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_11_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_12_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_14_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_10_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/east/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_5_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_6_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_1_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_4_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_7_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_0_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_3_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/west/bin/out_2_0.elf
@0 Reading ELF file /tmp/sdk-examples/benchmarks/spmv-hypersparse/out/generated/MEMCPY_XY_ROUTES.elf
@0 Invocation key is: sim9888033D95A46690D08E1F53987F1198
@0 Plan key is: plan34A3D4139F5F8BE0CD504134808A3823
@0 SimTraceCtf, flags:  wavelets=0 landing=1 inst=1 switch_positions=0 stalls=1
@0 P0.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P2.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P3.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P4.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P5.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P6.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P7.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P8.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P9.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P10.0 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P1.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.1 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.1 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.2 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.2 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.2 (nul) tile trace flag: inst_trace,landing,stalls
@0 P0.3 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.3 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P0.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P1.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P2.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P3.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P4.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P5.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P6.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P7.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P8.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P9.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P10.4 (hwtile) tile trace flag: inst_trace,landing,stalls
@0 P0.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P1.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P2.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P3.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P4.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P5.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P6.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P7.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P8.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P9.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 P10.5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW1 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LW2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LW4 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LW5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LE3 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LE4 (iotile) tile trace flag: inst_trace,landing,stalls
@0 LE5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN4 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN6 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN7 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN8 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN9 (nul) tile trace flag: inst_trace,landing,stalls
@0 LN10 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS0 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS1 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS2 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS3 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS4 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS5 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS6 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS7 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS8 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS9 (nul) tile trace flag: inst_trace,landing,stalls
@0 LS10 (nul) tile trace flag: inst_trace,landing,stalls
@0 Architecture is: SDR
@0 Simtile is: hwtile
@0 Sim stats: config-time=0.03, nodes=1, threads=5
@0 Sim stats: tiles=100, simulated_tiles=44, hwtile=40, iotile=4, nultile=56
@21926 50 cycles since an instruction was executed, 86 cycles since a wavelet landed
@21926 No data movement in the last 50 cycles; stopping.
@21926 Simulation used 4.13 seconds, init-time=0.11, total-time=4.24, cycles=21926, cyc/sec=5307.84, tile-cyc/sec=233545.09, tile-cyc/sec-thread=46709.02
@21926 CTF Stats: num_stalls_       =            0
@21926 CTF Stats: num_wavelets      =        19305
@21926 CTF Stats: num_inst_dispatch =       204729
@21926 CTF Stats: num_inst_pipe     =       812811
@21926 CTF Stats: num_switch_pos    =            0
```
</details>